### PR TITLE
add w, e, b, ge, to evil-cp-regular-movement-keys

### DIFF
--- a/evil-cleverparens.el
+++ b/evil-cleverparens.el
@@ -1389,7 +1389,11 @@ swallowed by the comment."
 ;;; Keys ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defvar evil-cp-regular-movement-keys
-  '(("W"  . evil-cp-forward-symbol-begin)
+  '(("w"  . evil-forward-word-begin)
+    ("e"  . evil-forward-word-end)
+    ("b"  . evil-backward-word-begin)
+    ("ge" . evil-backward-word-end)
+    ("W"  . evil-cp-forward-symbol-begin)
     ("E"  . evil-cp-forward-symbol-end)
     ("B"  . evil-cp-backward-symbol-begin)
     ("gE" . evil-cp-backward-symbol-end)))


### PR DESCRIPTION
Setting 'evil-cleverparens-swap-movement-by-word-and-symbol' to t
defines keys for w, e, b, and ge, in normal state while in
evil-cleverparens. Because these keys were not given explicit bindings
in 'evil-cp-regular-movement-keys', defaults were not being restored
when setting 'evil-cleverparens-swap-movement-by-word-and-symbol' back
to nil.
