### PR TITLE
Use current-column for getting current column number

### DIFF
--- a/evil-cleverparens.el
+++ b/evil-cleverparens.el
@@ -1355,7 +1355,7 @@ sexp regardless of what level the point is currently at."
                 (cl-incf offset))))
           (backward-char offset)))
     (when (not (eobp))
-      (let* ((col-pos (column-number-at-pos (point)))
+      (let* ((col-pos (current-column))
              (end     (point-at-eol))
              (line    (buffer-substring-no-properties (point-at-bol) end)))
         (goto-char end)


### PR DESCRIPTION
Emacs does not provide column-number-at-point.
