### PR TITLE
evil-snipe compatibility

### DIFF
--- a/evil-cleverparens.el
+++ b/evil-cleverparens.el
@@ -1986,8 +1986,6 @@ and/or beginning."
     ("y"   . evil-cp-yank)
     ("D"   . evil-cp-delete-line)
     ("C"   . evil-cp-change-line)
-    ("s"   . evil-cp-substitute)
-    ("S"   . evil-cp-change-whole-line)
     ("Y"   . evil-cp-yank-line)
     ("x"   . evil-cp-delete-char-or-splice)
     ("X"   . evil-cp-delete-char-or-splice-backwards)
@@ -2072,7 +2070,13 @@ in question."
       "i" 'evil-cp-insert
       "a" 'evil-cp-append)
     (add-hook 'evil-insert-state-exit-hook
-              'evil-cp-insert-exit-hook)))
+              'evil-cp-insert-exit-hook))
+  ;; If evil-snipe is not present or does not want to use s and S bindings,
+  ;; then we can use them. To take effect, evil-snipe must be loaded before us.
+  (when (not (bound-and-true-p evil-snipe-auto-disable-substitute))
+    (evil-define-key 'normal evil-cleverparens-mode-map
+      "s" 'evil-cp-substitute
+      "S" 'evil-cp-change-whole-line)))
 
 ;;;###autoload
 (defun evil-cp-set-additional-movement-keys ()


### PR DESCRIPTION
Hello -
Cleverparens today maps s and S in normal state unconditionally. It prevents these keybindings from being used by evil-snipe. Evil-snipe itself uses a variable to define when it has to overload these keys. By default it is overloaded, since as evil-snipe correctly puts it in a comment "they are mostly redundant with other motions," but the user can overturn it.

I suggest using the same variable before mapping s and S keys.

Thanks for a terrific package, by the way. The additional text objects by themselves worth the price of admission - can't imagine working without d and f now.
