### PR TITLE
Add option not to override s and S

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ If for some reason `evil-cleverparens` messes up, or you would just like to tort
 
 - `s` is identical to `evil`'s, but skips over delimiteres.
 - `S` is the same as `C` but always starts from the beginning of the line and skips over any unmatched delimiters.
+- `evil-cleverparens-use-s-and-S` (defaults to `t`) controls whether s and S will be overridden as described above. If you decide to set this to `nil`, do it **before** loading `evil-cleverparens`!
 
 #### `x` deletes and splices
 

--- a/evil-cleverparens.el
+++ b/evil-cleverparens.el
@@ -118,6 +118,12 @@ sexps or should lines be considered as well."
   :type 'boolean
   :group 'evil-cleverparens)
 
+(defcustom evil-cleverparens-use-s-and-S t
+  "Should we bind s and S, thus shadowing any existing bindings
+to these keys."
+  :type 'boolean
+  :group 'evil-cleverparens)
+
 (defcustom evil-cleverparens-enabled-hook nil
   "Called after `evil-cleverparens-mode' is turned on."
   :type 'hook
@@ -2073,7 +2079,8 @@ in question."
               'evil-cp-insert-exit-hook))
   ;; If evil-snipe is not present or does not want to use s and S bindings,
   ;; then we can use them. To take effect, evil-snipe must be loaded before us.
-  (when (not (bound-and-true-p evil-snipe-auto-disable-substitute))
+  (when (and evil-cleverparens-use-s-and-S
+             (not (bound-and-true-p evil-snipe-auto-disable-substitute)))
     (evil-define-key 'normal evil-cleverparens-mode-map
       "s" 'evil-cp-substitute
       "S" 'evil-cp-change-whole-line)))


### PR DESCRIPTION
At first, I would like to thank you for the useful package. Good work! :+1:

This PR adds a new boolean option `evil-cleverparens-use-s-and-S` to prevent shadowing of `s` and `S`.

Current code can only detect `evil-snipe`'s use of s and S, with implications on the packages load order. Since I use Avy on s and S, after activation of the `evil-cleverparens` I ended up without my bindings on these keys. My current workaround is:

``` emacs-lisp
(with-eval-after-load 'evil-cleverparens
  (evil-define-key 'normal evil-cleverparens-mode-map
    ;; I use s and S for Avy.
    "s" nil
    "S" nil))
```

But I feel that having a separate flag for this is a cleaner way to address the issue.
