### PR TITLE
fix x command to really delete a char

### DIFF
--- a/evil-cleverparens.el
+++ b/evil-cleverparens.el
@@ -1987,7 +1987,7 @@ and/or beginning."
     ("D"   . evil-cp-delete-line)
     ("C"   . evil-cp-change-line)
     ("Y"   . evil-cp-yank-line)
-    ("x"   . evil-cp-delete-char-or-splice)
+    ("x"   . evil-delete-char)
     ("X"   . evil-cp-delete-char-or-splice-backwards)
     (">"   . evil-cp->)
     ("<"   . evil-cp-<)


### PR DESCRIPTION
`x` was not working to delete a char, it returns this error:
`or: Wrong type argument: char-or-string-p, nil`
