### PR TITLE
Run the progn form intended when enabling evil-cleverparens-mode

### DIFF
--- a/evil-cleverparens.el
+++ b/evil-cleverparens.el
@@ -2128,6 +2128,7 @@ true."
 (evil-cp-set-additional-bindings)
 (evil-cp-set-additional-movement-keys)
 (evil-cp--enable-C-w-delete)
+(evil-cp--enable-text-objects)
 
 ;;;###autoload
 (define-minor-mode evil-cleverparens-mode
@@ -2140,7 +2141,6 @@ for an advanced modal structural editing experience."
                        "/b" "/i")))
   :init-value nil
   (if evil-cleverparens-mode
-      (evil-cp--enable-text-objects)
       (progn
         (if (bound-and-true-p evil-surround-mode)
             (evil-cp--enable-surround-operators)


### PR DESCRIPTION
* Run it instead of running the straggling line from fc4eb59 enabling textobjs (and move that line to the correct location, running upon require along with evil-cp's other keybinding functions)
* Fix likely cause of #49 (once again integrates safe operators, automatically, with evil-surround-mode)
* Prevent running evil-cleverparens-enabled-hook when evil-cleverparens-mode is in fact disabled, and instead run the the enabled hook when the mode is enabled