### PR TITLE
Add wrappers of `evil-change' to `evil-change-commands'

### DIFF
--- a/evil-cleverparens.el
+++ b/evil-cleverparens.el
@@ -936,7 +936,7 @@ working. Could be used to implement a future
            (evil-forward-beginning thing count))
 
           ((and evil-want-change-word-to-end
-                (eq evil-this-operator #'evil-change)
+                (memq evil-this-operator evil-change-commands)
                 (< orig (or (cdr-safe (bounds-of-thing-at-point thing)) orig)))
            (forward-thing thing count))
 
@@ -2065,6 +2065,9 @@ in question."
      evil-cp-regular-bindings
      state
      t))
+  ;; Enable `evil-cp-change' as an `evil-change command'.
+  (add-to-list 'evil-change-commands #'evil-cp-change)
+
   (if evil-cleverparens-use-regular-insert
       ;; in case we change our mind
       (progn


### PR DESCRIPTION
I recently added a new variable to evil, `evil-change-commands` which allows some evil-change workarounds to be applied to `evil-cp-change` and similar commands. 

This fixes #59.

I haven't had a chance to see if the new workarounds interfere with any evil-cp functions. I'll follow up if I find any issues (once evil get's a rebuild by tomorrow).

Please update your evil before testing this out!

See https://github.com/emacs-evil/evil/issues/916 for more information.