### PR TITLE
Replace obsoleted functions

### DIFF
--- a/evil-cleverparens-util.el
+++ b/evil-cleverparens-util.el
@@ -169,8 +169,8 @@ point lands is a safe region, in which case its bounds are
 returned."
   `(save-excursion
      ,@body
-     (let ((pbol (point-at-bol))
-           (peol (point-at-eol)))
+     (let ((pbol (line-beginning-position))
+           (peol (line-end-position)))
        (when (and (sp-region-ok-p pbol peol))
          (cons pbol peol)))))
 


### PR DESCRIPTION
point-at-bol and point-at-eol are obsoleted since Emacs 29.1

```
evil-cleverparens.el:531:17: Warning: ‘point-at-bol’ is an obsolete function
    (as of 29.1); use ‘line-beginning-position’ or ‘pos-bol’ instead.
evil-cleverparens.el:536:21: Warning: ‘point-at-eol’ is an obsolete function
    (as of 29.1); use ‘line-end-position’ or ‘pos-eol’ instead.
```