### PR TITLE
Deletion on closing delim, tests

### DIFF
--- a/evil-cleverparens-tests.el
+++ b/evil-cleverparens-tests.el
@@ -74,7 +74,12 @@
     (evil-cp-test-buffer
       "f[o]o"
       ("vlx")
-      "f")))
+      "f"))
+  (ert-info ("Can transpose chars")
+    (evil-cp-test-buffer
+      "([o]fo)"
+      ("xp")
+      "(f[o]o)")))
 
 (ert-deftest evil-cp-delete-char-or-splice-backwards-test ()
   (ert-info ("Can delete a normal character")
@@ -304,6 +309,11 @@ golf foxtrot deltahotel india"))
       "(Test [ ]        )"
       ("D")
       "(Test )"))
+  (ert-info ("Can delete empty form on closing delimiter")
+    (evil-cp-test-buffer
+      "(alpha ([)] bravo)"
+      ("D")
+      "(alpha[ ]bravo)"))
   (ert-info ("Can delete one-line comments")
     (evil-cp-test-buffer
       "([+] ;;This is a comment
@@ -352,6 +362,11 @@ golf foxtrot deltahotel india"))
       "[d]elta) echo\nfoxtrot"))) ;; TODO surely not desired?
 
 (ert-deftest evil-cp-change-test ()
+  (ert-info ("Can change word and keep spacing")
+    (evil-cp-test-buffer
+      "alpha [b]ravo charlie"
+      ("cw" "delta")
+      "alpha delta[] charlie"))
   (ert-info ("Can change up to end of symbol")
     (evil-cp-test-buffer
       "(((alpha b[r]avo-charlie)))"

--- a/evil-cleverparens.el
+++ b/evil-cleverparens.el
@@ -676,6 +676,10 @@ Stop ACTION when the first unbalanced closing delimeter or eol is reached."
            (evil-yank-characters beg end register)
            (delete-region beg end)))
 
+        ((and (evil-cp--looking-at-any-closing-p)
+              (evil-cp--looking-at-empty-form))
+         (evil-cp-delete-enclosing 1))
+
         ((save-excursion (paredit-skip-whitespace t (line-end-position))
                          (or (eolp) (eq (char-after) ?\; )))
          (when (paredit-in-char-p) (backward-char))
@@ -746,9 +750,6 @@ kill-ring is determined by the
                  (join-line 1)
                  (forward-line 1))
              (join-line 1)))
-
-          ((eq 'evil-end-of-line evil-this-motion)
-           (evil-cp-delete-line beg end type register yank-handler))
 
           (t (evil-cp-yank beg end type register yank-handler)
              (evil-cp--delete-characters beg end))))


### PR DESCRIPTION
Also, (temporarily?) remove `d$`=`D` logic