### PR TITLE
fix evil-cp-up-sexp getting stuck on closing quote

### DIFF
--- a/evil-cleverparens-tests.el
+++ b/evil-cleverparens-tests.el
@@ -551,7 +551,15 @@ golf foxtrot deltahotel india"))
       "alpha[ ]bravo"
       (evil-cp-set-additional-movement-keys)
       (")")
-      "alpha[ ]bravo")))
+      "alpha[ ]bravo"))
+  (ert-info ("Move if on quote")
+    (evil-cp-test-buffer
+      "(alpha (bravo \"char[l]ie\" delta) echo)"
+      (evil-cp-set-additional-movement-keys)
+      (")")
+      "(alpha (bravo \"charlie[\"] delta) echo)"
+      (")")
+      "(alpha (bravo \"charlie\" delta[)] echo)")))
 
 (ert-deftest evil-cp-forward-symbol-begin-test ()
   (ert-info ("Can move forward to the beginning of the next symbol")

--- a/evil-cleverparens.el
+++ b/evil-cleverparens.el
@@ -930,14 +930,14 @@ evil-motion."
       (sp-backward-up-sexp))))
 
 (evil-define-motion evil-cp-up-sexp (count)
-  "Motion for moving up to the previous level of parenteheses.
+  "Motion for moving up to the previous level of parentheses.
 The same as `sp-up-sexp', but leaves the point on top of the
 closing paren."
   :move-point nil
   :type inclusive
   (let ((count (or count 1))
         success)
-    (when (evil-cp--looking-at-closing-p) (forward-char))
+    (when (evil-cp--looking-at-any-closing-p) (forward-char))
     (dotimes (_ count)
       (and (sp-up-sexp) (setq success t)))
     (and success (backward-char))))


### PR DESCRIPTION
`evil-cp-up-sexp` get's stuck on closing quotes, for example in:
```
(message "%s" var)
```
with the cursor in the "%s" string, you do `evil-cp-up-sexp` once and it will move to the closing quote but then when you repeat `evil-cp-up-sexp` it will just stay stuck on the closing quote. It currently has a check if it is on a closing paren to move forward one char, I changed it so if it is on a closing paren or closing quote it will `forward-char`, and now it behaves as you expect. Starting with the cursor in the "%s" do `evil-cp-up-sexp` once and it will move to the closing quote, do `evil-cp-up-sexp` again and it will move to the closing paren.