### PR TITLE
Fix slurp/barf/drag for clojure tree-sitter mode

### DIFF
--- a/evil-cleverparens.el
+++ b/evil-cleverparens.el
@@ -1234,13 +1234,13 @@ regular forward-slurp."
 (defun evil-cp--cant-forward-sexp-p ()
   (save-excursion
     (condition-case nil
-        (forward-sexp)
+        (prog1 nil (forward-sexp))
       (error t))))
 
 (defun evil-cp--cant-backward-sexp-p ()
   (save-excursion
     (condition-case nil
-        (backward-sexp)
+        (prog1 nil (backward-sexp))
       (error t))))
 
 (defun evil-cp--last-symbol-of-form-p ()


### PR DESCRIPTION
`(forward-sexp)` and `(backward-sexp)` behave differently in tree-sitter mode, in that they return the new position of point rather than nil. This caused false-positives for `evil-cp--cant-forward-sexp-p` and `evil-cp--cant-backward-sexp-p`. As you only care about the error side-effect, wrapping them does the trick.