### PR TITLE
Fix graphical bindings for daemon terminal frames

### DIFF
--- a/evil-cleverparens-tests.el
+++ b/evil-cleverparens-tests.el
@@ -876,7 +876,15 @@ alpha (bravo (charlie delta) echo) foxtrot")))
         "(alpha bravo)\n[]\n(charlie delta)"
         (evil-cp-set-additional-bindings)
         ("\M-O" "echo")
-        "(alpha bravo)\necho[]\n\n(charlie delta)"))))
+        "(alpha bravo)\necho[]\n\n(charlie delta)")))
+  (let ((window-system t))
+    (ert-info ("Is unavailable under terminal")
+      (evil-cp-test-buffer
+        "(alpha (bravo [c]harlie) delta)"
+        (evil-cp-set-additional-bindings)
+        (setq window-system nil)
+        ("\M-O") ;; same as "\M-o" since "\M-O" is unavailable
+        "(alpha (bravo charlie)\n[]delta)"))))
 
 (ert-deftest evil-cp-yank-sexp-test ()
   (ert-info ("Can yank a sexp")
@@ -1088,7 +1096,15 @@ india[]
         (evil-cleverparens-mode t)
         (evil-cp-set-additional-bindings)
         ("\C-u\M-[")
-        "alpha [«[»bravo charlie delta]] echo"))))
+        "alpha [«[»bravo charlie delta]] echo")))
+  (let ((window-system t))
+    (ert-info ("Is unavailable under terminal")
+      (evil-cp-test-buffer
+        "(alpha [b]ravo)"
+        (evil-cp-set-additional-bindings)
+        (setq window-system nil)
+        ("\M-[")
+        "(alpha [b]ravo)"))))
 
 (ert-deftest evil-cp-wrap-previous-square-test ()
   (let ((window-system t))
@@ -1124,7 +1140,15 @@ india[]
         (evil-cleverparens-mode t)
         (evil-cp-set-additional-bindings)
         ("\C-u\M-]")
-        "alpha [[bravo charlie delta]«]» echo")))) ;; TODO inconsistent cursor with wrap-next-square
+        "alpha [[bravo charlie delta]«]» echo"))) ;; TODO inconsistent cursor with wrap-next-square
+  (let ((window-system t))
+    (ert-info ("Is unavailable under terminal")
+      (evil-cp-test-buffer
+        "(alpha [b]ravo)"
+        (evil-cp-set-additional-bindings)
+        (setq window-system nil)
+        ("\M-]")
+        "(alpha [b]ravo)"))))
 
 (ert-deftest evil-cp-wrap-next-curly-test ()
   (ert-info ("Can wrap next sexp with curly braces")

--- a/evil-cleverparens.el
+++ b/evil-cleverparens.el
@@ -2178,6 +2178,15 @@ for normal, visual and operator states if
      state
      evil-cleverparens-use-additional-movement-keys)))
 
+(defun evil-cp--wrap-graphical-binding (binding-pair)
+  "Wraps a key binding in a `menu-item' with a filter so that it is only
+effective under graphical sessions."
+  (let ((key (car binding-pair))
+        (binding (cdr binding-pair)))
+    (cons key
+          `(menu-item "" ,binding :filter
+                      ,(lambda (binding) (if window-system binding))))))
+
 ;;;###autoload
 (defun evil-cp-set-additional-bindings ()
   "Sets the movement keys is `evil-cp-additional-bindings' for
@@ -2188,11 +2197,11 @@ true."
    evil-cp-additional-bindings
    'normal
    evil-cleverparens-use-additional-bindings)
-  (when window-system
-    (evil-cp--populate-mode-bindings-for-state
-     evil-cp-additional-bindings-graphical
-     'normal
-     evil-cleverparens-use-additional-bindings)))
+  (evil-cp--populate-mode-bindings-for-state
+   (mapcar #'evil-cp--wrap-graphical-binding
+           evil-cp-additional-bindings-graphical)
+   'normal
+   evil-cleverparens-use-additional-bindings))
 
 (defun evil-cp--enable-C-w-delete ()
   (when evil-want-C-w-delete


### PR DESCRIPTION
Issue #58 seems to still cause problems for Emacs running in daemon mode.

Instead of detecting `window-system` at load time, this PR uses `menu-item` to probe `window-system` at runtime, returning `nil` for terminal sessions.

A similar trick has been used by Evil for `ESC` handling in terminals [#13793; 24.3.50; M-x broken in viper and X](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=13793#16):

https://github.com/emacs-evil/evil/blob/682e87fce99f39ea3155f11f87ee56b6e4593304/evil-core.el#L589-L590

fixes #58 